### PR TITLE
Oct 22 : Jishnu Roy : Path change for rib-[in|out]-[pre|post] in ietf-bgp-origin-as-validation.yang|tree

### DIFF
--- a/ietf-bgp-origin-as-validation.tree
+++ b/ietf-bgp-origin-as-validation.tree
@@ -8,25 +8,25 @@ module: ietf-bgp-origin-as-validation
     +--rw origin-as-validation
        +--rw enabled?             boolean
        +--rw redistribution-as?   inet:as-number
-  augment /rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:rib/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:rib-in-pre:
+  augment /rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:rib/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:neighbors/bgp:neighbor/bgp:adj-rib-in-pre:
     +--ro statistics
        +--ro validation-state-unverified?   yang:gauge32
        +--ro validation-state-unknown?      yang:gauge32
        +--ro validation-state-invalid?      yang:gauge32
        +--ro validation-state-valid?        yang:gauge32
-  augment /rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:rib/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:rib-in-pre:
+  augment /rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:rib/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:neighbors/bgp:neighbor/bgp:adj-rib-in-pre:
     +--ro statistics
        +--ro validation-state-unverified?   yang:gauge32
        +--ro validation-state-unknown?      yang:gauge32
        +--ro validation-state-invalid?      yang:gauge32
        +--ro validation-state-valid?        yang:gauge32
-  augment /rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:rib/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:rib-in-post:
+  augment /rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:rib/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:neighbors/bgp:neighbor/bgp:adj-rib-in-post:
     +--ro statistics
        +--ro validation-state-unverified?   yang:gauge32
        +--ro validation-state-unknown?      yang:gauge32
        +--ro validation-state-invalid?      yang:gauge32
        +--ro validation-state-valid?        yang:gauge32
-  augment /rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:rib/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:rib-in-post:
+  augment /rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:rib/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:neighbors/bgp:neighbor/bgp:adj-rib-in-post:
     +--ro statistics
        +--ro validation-state-unverified?   yang:gauge32
        +--ro validation-state-unknown?      yang:gauge32
@@ -44,25 +44,25 @@ module: ietf-bgp-origin-as-validation
        +--ro validation-state-unknown?      yang:gauge32
        +--ro validation-state-invalid?      yang:gauge32
        +--ro validation-state-valid?        yang:gauge32
-  augment /rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:rib/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:rib-out-pre:
+  augment /rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:rib/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:neighbors/bgp:neighbor/bgp:adj-rib-out-pre:
     +--ro statistics
        +--ro validation-state-unverified?   yang:gauge32
        +--ro validation-state-unknown?      yang:gauge32
        +--ro validation-state-invalid?      yang:gauge32
        +--ro validation-state-valid?        yang:gauge32
-  augment /rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:rib/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:rib-out-pre:
+  augment /rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:rib/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:neighbors/bgp:neighbor/bgp:adj-rib-out-pre:
     +--ro statistics
        +--ro validation-state-unverified?   yang:gauge32
        +--ro validation-state-unknown?      yang:gauge32
        +--ro validation-state-invalid?      yang:gauge32
        +--ro validation-state-valid?        yang:gauge32
-  augment /rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:rib/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:rib-out-post:
+  augment /rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:rib/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:neighbors/bgp:neighbor/bgp:adj-rib-out-post:
     +--ro statistics
        +--ro validation-state-unverified?   yang:gauge32
        +--ro validation-state-unknown?      yang:gauge32
        +--ro validation-state-invalid?      yang:gauge32
        +--ro validation-state-valid?        yang:gauge32
-  augment /rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:rib/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:rib-out-post:
+  augment /rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/bgp:bgp/bgp:rib/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:neighbors/bgp:neighbor/bgp:adj-rib-out-post:
     +--ro statistics
        +--ro validation-state-unverified?   yang:gauge32
        +--ro validation-state-unknown?      yang:gauge32

--- a/ietf-bgp-origin-as-validation.yang
+++ b/ietf-bgp-origin-as-validation.yang
@@ -266,7 +266,7 @@
      augment "/rt:routing/rt:control-plane-protocols"
            + "/rt:control-plane-protocol/bgp:bgp/bgp:rib"
            + "/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast"
-           + "/bgp:rib-in-pre" {
+           + "/bgp:neighbors/bgp:neighbor/bgp:adj-rib-in-pre" {
        description
          "Augmentation of BGP IPv4 Unicast route statistics.";
 
@@ -276,7 +276,7 @@
      augment "/rt:routing/rt:control-plane-protocols"
            + "/rt:control-plane-protocol/bgp:bgp/bgp:rib"
            + "/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast"
-           + "/bgp:rib-in-pre" {
+           + "/bgp:neighbors/bgp:neighbor/bgp:adj-rib-in-pre" {
        description
          "Augmentation of BGP IPv6 Unicast route statistics.";
 
@@ -286,7 +286,7 @@
      augment "/rt:routing/rt:control-plane-protocols"
            + "/rt:control-plane-protocol/bgp:bgp/bgp:rib"
            + "/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast"
-           + "/bgp:rib-in-post" {
+           + "/bgp:neighbors/bgp:neighbor/bgp:adj-rib-in-post" {
        description
          "Augmentation of BGP IPv4 Unicast route statistics.";
 
@@ -296,7 +296,7 @@
      augment "/rt:routing/rt:control-plane-protocols"
            + "/rt:control-plane-protocol/bgp:bgp/bgp:rib"
            + "/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast"
-           + "/bgp:rib-in-post" {
+           + "/bgp:neighbors/bgp:neighbor/bgp:adj-rib-in-post" {
        description
          "Augmentation of BGP IPv6 Unicast route statistics.";
 
@@ -326,7 +326,7 @@
      augment "/rt:routing/rt:control-plane-protocols"
            + "/rt:control-plane-protocol/bgp:bgp/bgp:rib"
            + "/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast"
-           + "/bgp:rib-out-pre" {
+           + "/bgp:neighbors/bgp:neighbor/bgp:adj-rib-out-pre" {
        description
          "Augmentation of BGP IPv4 Unicast route statistics.";
 
@@ -336,7 +336,7 @@
      augment "/rt:routing/rt:control-plane-protocols"
            + "/rt:control-plane-protocol/bgp:bgp/bgp:rib"
            + "/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast"
-           + "/bgp:rib-out-pre" {
+           + "/bgp:neighbors/bgp:neighbor/bgp:adj-rib-out-pre" {
        description
          "Augmentation of BGP IPv6 Unicast route statistics.";
 
@@ -346,7 +346,7 @@
      augment "/rt:routing/rt:control-plane-protocols"
            + "/rt:control-plane-protocol/bgp:bgp/bgp:rib"
            + "/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast"
-           + "/bgp:rib-out-post" {
+           + "/bgp:neighbors/bgp:neighbor/bgp:adj-rib-out-post" {
        description
          "Augmentation of BGP IPv4 Unicast route statistics.";
 
@@ -356,7 +356,7 @@
      augment "/rt:routing/rt:control-plane-protocols"
            + "/rt:control-plane-protocol/bgp:bgp/bgp:rib"
            + "/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast"
-           + "/bgp:rib-out-post" {
+           + "/bgp:neighbors/bgp:neighbor/bgp:adj-rib-out-post" {
        description
          "Augmentation of BGP IPv6 Unicast route statistics.";
 


### PR DESCRIPTION
Changes in .yang and .tree files for ietf-bgp-origin-as-validation.